### PR TITLE
Support only single file

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -64,13 +64,22 @@ class NetCDFFUSE(Operations):
     - could be refactored lateer.)
     """
 
-    def __init__(self, filerootdir):
-        self.filerootdir = os.path.realpath(filerootdir)
+    def __init__(self, fileroot):
+        self.fileroot = os.path.realpath(fileroot)
         self.readwritelock = Lock()
+        self._checkinput()
 
     def __call__(self, operation, path, *args):
         return super(NetCDFFUSE, self).__call__(
-            operation, self.filerootdir + path, *args)
+            operation, self.fileroot + path, *args)
+
+    def _checkinput(self):
+        try:
+            ncpy.Dataset(self.fileroot, "r")
+        except IOError as err:
+            print(err, "You must provide a path to a valid netCDF file")
+            print("Not a valid netCDF file: ", self.fileroot)
+            sys.exit(1)
 
     class NetCDFComponent:
         """

--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -184,63 +184,67 @@ class NetCDFFUSE(Operations):
                             ('st_atime', 'st_ctime', 'st_gid', 'st_mode',
                              'st_mtime', 'st_nlink',
                              'st_size', 'st_uid'))
-            if self.dataset_file is not None:
+            if self.dataset_file is None:
+                return statdict
+            if DEBUG:
+                print("NETCDF_FILE:    ", self.dataset_file)
+                print("INTERNALPATH: ", self.internalpath)
+            if self.internalpath == "/":
                 if DEBUG:
-                    print("NETCDF_FILE:    ", self.dataset_file)
-                    print("INTERNALPATH: ", self.internalpath)
-                if self.internalpath == "/":
-                    if DEBUG:
-                        print("at a filepath slash...")
-                    statdict = self.makeIntoDir(statdict)
+                    print("at a filepath slash...")
+                statdict = self.makeIntoDir(statdict)
 
-                # Are we at the top of the netCDF mountpoint?
-                elif self.internalpath == "":
-                    if DEBUG:
-                        print("WE ARE AT THE TOP: ", self.internalpath)
-                    statdict = self.makeIntoDir(statdict)
-                    statdict['st_size'] = 4096
+            # Are we at the top of the netCDF mountpoint?
+            elif self.internalpath == "":
+                if DEBUG:
+                    print("WE ARE AT THE TOP: ", self.internalpath)
+                statdict = self.makeIntoDir(statdict)
+                statdict['st_size'] = 4096
 
-                # Are we at a variable?
-                elif self.internalpath in self.ncVars:
-                    if DEBUG:
-                        print("WE ARE AT VARIABLE: ", self.internalpath)
-                    statdict = self.makeIntoDir(statdict)
-                    statdict['st_size'] = 4096
+            # Are we at a variable?
+            elif self.internalpath in self.ncVars:
+                if DEBUG:
+                    print("WE ARE AT VARIABLE: ", self.internalpath)
+                statdict = self.makeIntoDir(statdict)
+                statdict['st_size'] = 4096
 
-                # Are these next two cases now actually doing the same thing?
-                elif "DATA_REPR" in self.internalpath:
-                    if DEBUG:
-                        print("WE ARE INSIDE A VARIABLE DIR (WITH DATA_REPR): ",
-                              self.internalpath)
-                    var = self.dataset_handle.variables[
-                        self.internalpath.split('/')[0]]
-                    # res = "%s" % var[:]
-                    res = repr(var[:])
-                    statdict['st_size'] = len(res)  # 0
+            # Are these next two cases now actually doing the same thing?
+            elif "DATA_REPR" in self.internalpath:
+                if DEBUG:
+                    print("WE ARE INSIDE A VARIABLE DIR (WITH DATA_REPR): ",
+                          self.internalpath)
+                var = self.dataset_handle.variables[
+                    self.internalpath.split('/')[0]]
+                # res = "%s" % var[:]
+                res = repr(var[:])
+                statdict['st_size'] = len(res)  # 0
 
-                # Are we inside a variable directory?
-                elif any(variable in self.internalpath for variable in self.ncVars):  # and '/' in self.internalpath:
-                #elif '/' in self.internalpath:
-                    if DEBUG:
-                        print("WE ARE INSIDE A VARIABLE DIR: ", self.internalpath)
-                    path, var_attr_name = self.internalpath.split('/')
-                    if DEBUG:
-                        print("#MSG: var, attr: ", path, var_attr_name)
-                        print("#MSG: Available attrs: ", self.dataset_handle.variables[path].ncattrs())
-                    # Check we are not trying to use a non-existent attribute
-                    if var_attr_name not in self.dataset_handle.variables[path].ncattrs():
-                        print("ITEM NOT FOUND: ", var_attr_name, self.internalpath)
-                        raise FuseOSError(ENOENT)
-
-                    # Return the correct stat for a variable attribute
-                    var = self.dataset_handle.variables[path]
-                    res = var_attr_name_to_str(var_attr_name, var)
-                    if res is not None:
-                        statdict['st_size'] = len(res)
-                else:
-                    if DEBUG:
-                        print("ITEM NOT FOUND: ", self.internalpath)
+            # Are we inside a variable directory?
+            elif any(varbl in self.internalpath for varbl in self.ncVars):
+                # and '/' in self.internalpath:
+                # elif '/' in self.internalpath:
+                if DEBUG:
+                    print("WE ARE INSIDE A VARIABLE DIR: ", self.internalpath)
+                path, var_attr_name = self.internalpath.split('/')
+                if DEBUG:
+                    print("#MSG: var, attr: ", path, var_attr_name)
+                    print("#MSG: Available attrs: ",
+                          self.dataset_handle.variables[path].ncattrs())
+                # Check we are not trying to use a non-existent attribute
+                if (var_attr_name not in
+                        self.dataset_handle.variables[path].ncattrs()):
+                    print("ITEM NOT FOUND: ", var_attr_name, self.internalpath)
                     raise FuseOSError(ENOENT)
+
+                # Return the correct stat for a variable attribute
+                var = self.dataset_handle.variables[path]
+                res = var_attr_name_to_str(var_attr_name, var)
+                if res is not None:
+                    statdict['st_size'] = len(res)
+            else:
+                if DEBUG:
+                    print("ITEM NOT FOUND: ", self.internalpath)
+                raise FuseOSError(ENOENT)  # Is this correct return object?
             return statdict
 
         def getxattr(self, name):
@@ -337,7 +341,8 @@ class NetCDFFUSE(Operations):
                 # print(sys.exc_info()[0])
             # pp.pformat(self.internalpath)
             # pp.pformat(self.dataset_handle)
-            print("# READ", size, offset, fh, "# INTERNAL PATH", self.internalpath)
+            print("# READ", size, offset, fh)
+            print("# INTERNAL PATH", self.internalpath)
             # if os.isatty(sys.stdout.fileno()):
             # print("# DH ", self.dataset_handle)
             # type 'netCDF4._netCDF4.Dataset'

--- a/test/test_fusenetcdf.py
+++ b/test/test_fusenetcdf.py
@@ -10,7 +10,7 @@ class testFuseNetcdf(unittest.TestCase):
     def setUpClass(self):
         # Set up test file object
         self.PATH = "trial/ECMWF_ERA-40_subset.nc"
-        self.NCFILE = fnc.NetCDFFUSE.PotentialNetCDFFile(self.PATH)
+        self.NCFILE = fnc.NetCDFFUSE.NetCDFComponent(self.PATH)
 
     def test_testNetCDF(self):
         """


### PR DESCRIPTION
Checks that only a single netCDF has been provided for mounting to the VFS (i.e. don't try to support multiple files/directories) can also simplify some of the other code now with this change applied.