### PR TITLE
Implemented renaming dimensions and dimension variables consistently

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -132,7 +132,6 @@ class DimNamesAsTextFiles(object):
         return dimnames_repr.strip().split('\n')
 
 
-
 #
 # NetCDF filesystem implementation
 #

--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -115,21 +115,24 @@ class AttributesAsTextFiles(object):
 
 class DimNamesAsTextFiles(object):
 
-    def __init__(self):
-        pass
+    def __init__(self, sep='\n'):
+        self._sep = sep
 
     def size(self, dimnames):
         return len(self.encode(dimnames))
 
     def encode(self, dimnames):
         """ Return text representation of a list of dimension names"""
-        return ''.join([s + '\n' for s in dimnames])
+        s = self._sep.join(dimnames)
+        if not s or s[-1] == '\n':
+            return s
+        return s + '\n'
 
     def decode(self, dimnames_repr):
         """ Convert text representation back to data """
         if not dimnames_repr:
             return []
-        return dimnames_repr.strip().split('\n')
+        return dimnames_repr.strip().split(self._sep)
 
 
 #

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -156,35 +156,46 @@ class TestWrite(unittest.TestCase):
 class TestDimNamesAsTextFiles(unittest.TestCase):
 
     def setUp(self):
-        self.dimnames_repr = DimNamesAsTextFiles()
+        self.mapping = DimNamesAsTextFiles()
 
     def test_encode(self):
         dimnames = [u'longitude', u'latitude', u'time']
         expected_repr = 'longitude\nlatitude\ntime\n'
         self.assertMultiLineEqual(
-                self.dimnames_repr.encode(dimnames), expected_repr)
+                self.mapping.encode(dimnames), expected_repr)
+
+    def test_encode_with_custom_separator(self):
+        mapping = DimNamesAsTextFiles(sep=', ')
+        dimnames = [u'longitude', u'latitude', u'time']
+        expected_repr = 'longitude, latitude, time\n'
+        self.assertMultiLineEqual(mapping.encode(dimnames), expected_repr)
 
     def test_encode_empty_list(self):
         dimnames = []
         expected_repr = ''
         self.assertMultiLineEqual(
-                self.dimnames_repr.encode(dimnames), expected_repr)
+                self.mapping.encode(dimnames), expected_repr)
 
     def test_decode(self):
         dimnames_repr = 'longitude\nlatitude\ntime\n'
         expected_dimnames = [u'longitude', u'latitude', u'time']
         self.assertEqual(
-                self.dimnames_repr.decode(dimnames_repr), expected_dimnames)
+                self.mapping.decode(dimnames_repr), expected_dimnames)
+
+    def test_decode_with_custom_separator(self):
+        mapping = DimNamesAsTextFiles(sep=', ')
+        dimnames_repr = 'longitude, latitude, time\n'
+        expected_dimnames = [u'longitude', u'latitude', u'time']
+        self.assertEqual(mapping.decode(dimnames_repr), expected_dimnames)
 
     def test_decode_empty_string(self):
         dimnames_repr = ''
         expected_dimnames = []
-        self.assertEqual(
-                self.dimnames_repr.decode(dimnames_repr), expected_dimnames)
+        self.assertEqual(self.mapping.decode(dimnames_repr), expected_dimnames)
 
     def test_size(self):
         dimnames = [u'x', u'y', u'z']
-        self.assertEqual(self.dimnames_repr.size(dimnames), 6)
+        self.assertEqual(self.mapping.size(dimnames), 6)
 
 
 class TestDimensions(unittest.TestCase):

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -1,12 +1,13 @@
 import unittest
 from fusenetcdf.fusenetcdf import NCFS
 from netCDF4 import Dataset
+from fusenetcdf.fusenetcdf import DimNamesAsTextFiles
 
 
 class TestIsVarDir(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None)
+        self.ncfs = NCFS(None, None, None, None)
 
     def test_is_var_dir_1(self):
         self.assertTrue(self.ncfs.is_var_dir('/abcd'))
@@ -24,7 +25,7 @@ class TestIsVarDir(unittest.TestCase):
 class TestIsVarData(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None)
+        self.ncfs = NCFS(None, None, None, None)
 
     def test_is_var_data_1(self):
         self.assertFalse(self.ncfs.is_var_data('/abcd'))
@@ -42,7 +43,7 @@ class TestIsVarData(unittest.TestCase):
 class TestIsVarAttribute(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None)
+        self.ncfs = NCFS(None, None, None, None)
 
     def test_is_var_attr_1(self):
         self.assertFalse(self.ncfs.is_var_attr('/abcd'))
@@ -57,7 +58,19 @@ class TestIsVarAttribute(unittest.TestCase):
         self.assertFalse(self.ncfs.is_var_attr('/abcd/DATA_REPR'))
 
     def test_is_var_attr_5(self):
-        self.assertFalse(self.ncfs.is_var_attr('/abcd/dimensions'))
+        self.assertFalse(self.ncfs.is_var_attr('/abcd/DIMENSIONS'))
+
+
+class TestIsVariableDimensions(unittest.TestCase):
+
+    def setUp(self):
+        self.ncfs = NCFS(None, None, None, None)
+
+    def test_is_var_dimensions_1(self):
+        self.assertTrue(self.ncfs.is_var_dimensions('/abcd/DIMENSIONS'))
+
+    def test_is_var_dimensions_2(self):
+        self.assertFalse(self.ncfs.is_var_dimensions('/abcd/DATA_REPR'))
 
 
 class FakeVariable(object):
@@ -76,7 +89,7 @@ class TestExists(unittest.TestCase):
 
     def setUp(self):
         dataset = FakeDataset()
-        self.ncfs = NCFS(dataset, None, None)
+        self.ncfs = NCFS(dataset, None, None, None)
 
     def test_exists_1(self):
         self.assertTrue(self.ncfs.exists('/foovar'))
@@ -94,13 +107,18 @@ class TestExists(unittest.TestCase):
         self.assertTrue(self.ncfs.exists('/foovar/DATA_REPR'))
 
     def test_exists_6(self):
-        self.assertTrue(self.ncfs.exists('/foovar/dimensions'))
+        self.assertTrue(self.ncfs.exists('/foovar/DIMENSIONS'))
 
 
 def create_test_dataset_1():
     ds = Dataset('test.nc', mode='w', diskless=True, format='NETCDF4')
+    # create Dimensions
     ds.createDimension('x', 3)
     ds.createDimension('y', 3)
+    # create a Dimension Variable (yes just one)
+    ds.createVariable('x', int, dimensions=('x'))
+    ds.variables['x'][:] = [1, 2, 3]
+    # create a Variable
     ds.createVariable('foovar', float, dimensions=('x', 'y'))
     v = ds.variables['foovar']
     v.setncattr('fooattr', 'abc')
@@ -111,7 +129,7 @@ class TestWrite(unittest.TestCase):
 
     def setUp(self):
         self.ds = create_test_dataset_1()
-        self.ncfs = NCFS(self.ds, None, None)
+        self.ncfs = NCFS(self.ds, None, None, None)
 
     def tearDown(self):
         self.ds.close()
@@ -135,12 +153,46 @@ class TestWrite(unittest.TestCase):
                           'foovar')
 
 
-@unittest.skip
+class TestDimNamesAsTextFiles(unittest.TestCase):
+
+    def setUp(self):
+        self.dimnames_repr = DimNamesAsTextFiles()
+
+    def test_encode(self):
+        dimnames = [u'longitude', u'latitude', u'time']
+        expected_repr = 'longitude\nlatitude\ntime\n'
+        self.assertMultiLineEqual(
+                self.dimnames_repr.encode(dimnames), expected_repr)
+
+    def test_encode_empty_list(self):
+        dimnames = []
+        expected_repr = ''
+        self.assertMultiLineEqual(
+                self.dimnames_repr.encode(dimnames), expected_repr)
+
+    def test_decode(self):
+        dimnames_repr = 'longitude\nlatitude\ntime\n'
+        expected_dimnames = [u'longitude', u'latitude', u'time']
+        self.assertEqual(
+                self.dimnames_repr.decode(dimnames_repr), expected_dimnames)
+
+    def test_decode_empty_string(self):
+        dimnames_repr = ''
+        expected_dimnames = []
+        self.assertEqual(
+                self.dimnames_repr.decode(dimnames_repr), expected_dimnames)
+
+    def test_size(self):
+        dimnames = [u'x', u'y', u'z']
+        self.assertEqual(self.dimnames_repr.size(dimnames), 6)
+
+
 class TestDimensions(unittest.TestCase):
 
     def setUp(self):
         self.ds = create_test_dataset_1()
-        self.ncfs = NCFS(self.ds, None, None)
+        dimnames_repr = DimNamesAsTextFiles()
+        self.ncfs = NCFS(self.ds, None, None, dimnames_repr)
 
     def tearDown(self):
         self.ds.close()
@@ -148,9 +200,34 @@ class TestDimensions(unittest.TestCase):
     def test_reading_dimensions(self):
         expected = 'x\ny\n'
         self.assertMultiLineEqual(
-                self.ncfs.read('/foovar/fooattr/dimensions', 4, 0), expected)
+                str(self.ncfs.read('/foovar/DIMENSIONS', 4, 0)), expected)
 
-    def test_renaming_dimensions(self):
-        self.ncfs.write('/foovar/fooattr/dimensions', 'lon\nlat\n', 8, 0)
+    def test_renaming_all_dimensions(self):
+        self.ncfs.write('/foovar/DIMENSIONS', 'lon\nlat\n', 0, 0)
         expected = (u'lon', u'lat')
+        # were dimensions renamed?
         self.assertEqual(self.ds.variables['foovar'].dimensions, expected)
+        # was the 'x' Dimension Variable renamed to 'lon'?
+        self.assertTrue('lon' in self.ds.variables)
+
+    def test_renaming_some_dimensions(self):
+        self.ncfs.write('/foovar/DIMENSIONS', 'x\nlat\n', 0, 0)
+        expected = (u'x', u'lat')
+        # were dimensions renamed?
+        self.assertEqual(self.ds.variables['foovar'].dimensions, expected)
+        # is the 'x' Dimension Variable still named 'x'?
+        self.assertTrue('x' in self.ds.variables)
+
+    def test_ignoring_invalid_edits(self):
+        # if new list has wrong number of dimensions, ingore the change
+        self.ncfs.write('/foovar/DIMENSIONS', 'a\nb\nc\n', 0, 0)
+        expected = (u'x', u'y')
+        self.assertEqual(self.ds.variables['foovar'].dimensions, expected)
+
+    def test_renamin_dimension_variable(self):
+        self.ncfs.rename('/x', 'lon')
+        # did renaming Dimension Variable also renamed corresponding Dimension?
+        self.assertFalse('x' in self.ds.variables)
+        self.assertTrue('lon' in self.ds.variables)
+        self.assertFalse('x' in self.ds.dimensions)
+        self.assertTrue('lon' in self.ds.dimensions)


### PR DESCRIPTION
Hi @dvalters,

This pull request implements renaming dimensions

- A Variable directory contains "DIMENSIONS" file with a list of dimension names
- One can edit this file to rename dimensions.
- Changing Dimension name will also change Dimension Variable name and vice-versa
- Invalid edits (e.g. ones that would change number of variable's dimensions) are ignored (warning is printed)
- Added unit tests for this functionality