### PR TITLE
Dimnames swap

### DIFF
--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -238,10 +238,22 @@ class TestDimensions(unittest.TestCase):
         expected = (u'x', u'y')
         self.assertEqual(self.ds.variables['foovar'].dimensions, expected)
 
-    def test_renamin_dimension_variable(self):
+    def test_renaming_dimension_variable(self):
         self.ncfs.rename('/x', 'lon')
         # did renaming Dimension Variable also renamed corresponding Dimension?
         self.assertFalse('x' in self.ds.variables)
         self.assertTrue('lon' in self.ds.variables)
         self.assertFalse('x' in self.ds.dimensions)
         self.assertTrue('lon' in self.ds.dimensions)
+
+    def test_swapping_dimension_names(self):
+        self.ncfs.write('/foovar/DIMENSIONS', 'y\nx\n', 0, 0)
+        self.assertEqual(self.ds.variables['foovar'].dimensions, (u'y', u'x'))
+        # did the 'x' Dimension Variable name change to 'y' ?
+        self.assertFalse('x' in self.ds.variables)
+        self.assertTrue('y' in self.ds.variables)
+
+    def test_duplicate_names(self):
+        self.ncfs.write('/foovar/DIMENSIONS', 'y\ny\n', 0, 0)
+        # was this edit ignored?
+        self.assertEqual(self.ds.variables['foovar'].dimensions, (u'x', u'y'))

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -4,10 +4,24 @@ from netCDF4 import Dataset
 from fusenetcdf.fusenetcdf import DimNamesAsTextFiles
 
 
+class FakeVariable(object):
+    def getncattr(self, name):
+        if name == 'fooattr':
+            return 'bar'
+        else:
+            raise AttributeError()
+
+
+class FakeDataset(object):
+    variables = {'foovar': FakeVariable()}
+    def ncattrs(self):
+        return {'attr1': 'val1', 'attr2': 'val2'}
+
+
 class TestIsVarDir(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None, None)
+        self.ncfs = NCFS(FakeDataset(), None, None, None)
 
     def test_is_var_dir_1(self):
         self.assertTrue(self.ncfs.is_var_dir('/abcd'))
@@ -25,7 +39,7 @@ class TestIsVarDir(unittest.TestCase):
 class TestIsVarData(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None, None)
+        self.ncfs = NCFS(FakeDataset(), None, None, None)
 
     def test_is_var_data_1(self):
         self.assertFalse(self.ncfs.is_var_data('/abcd'))
@@ -43,7 +57,7 @@ class TestIsVarData(unittest.TestCase):
 class TestIsVarAttribute(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None, None)
+        self.ncfs = NCFS(FakeDataset(), None, None, None)
 
     def test_is_var_attr_1(self):
         self.assertFalse(self.ncfs.is_var_attr('/abcd'))
@@ -64,7 +78,7 @@ class TestIsVarAttribute(unittest.TestCase):
 class TestIsVariableDimensions(unittest.TestCase):
 
     def setUp(self):
-        self.ncfs = NCFS(None, None, None, None)
+        self.ncfs = NCFS(FakeDataset(), None, None, None)
 
     def test_is_var_dimensions_1(self):
         self.assertTrue(self.ncfs.is_var_dimensions('/abcd/DIMENSIONS'))
@@ -73,23 +87,10 @@ class TestIsVariableDimensions(unittest.TestCase):
         self.assertFalse(self.ncfs.is_var_dimensions('/abcd/DATA_REPR'))
 
 
-class FakeVariable(object):
-    def getncattr(self, name):
-        if name == 'fooattr':
-            return 'bar'
-        else:
-            raise AttributeError()
-
-
-class FakeDataset(object):
-    variables = {'foovar': FakeVariable()}
-
-
 class TestExists(unittest.TestCase):
 
     def setUp(self):
-        dataset = FakeDataset()
-        self.ncfs = NCFS(dataset, None, None, None)
+        self.ncfs = NCFS(FakeDataset(), None, None, None)
 
     def test_exists_1(self):
         self.assertTrue(self.ncfs.exists('/foovar'))

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -13,7 +13,9 @@ class FakeVariable(object):
 
 
 class FakeDataset(object):
+
     variables = {'foovar': FakeVariable()}
+
     def ncattrs(self):
         return {'attr1': 'val1', 'attr2': 'val2'}
 


### PR DESCRIPTION
Hi @dvalters, some more changes for editing dimension names:
- edits which were swapping names of two dimensions did not work before, work now
- edits which would result in duplicate names are now ignored.
- added unit tests for these two cases