### PR TITLE
fixed invalid number of parameters in truncate() function call

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -158,7 +158,7 @@ class NCFS(object):
         """ Test if path is a valid Variable directory path """
         potential_vardir = self.get_varname(path)
         # Don't return True if it is a Global Attribute
-        if potential_vardir not in self.getncGlobalAttrs():
+        if potential_vardir not in self.dataset.ncattrs():
             return re.search('^/[^/]+$', path) is not None
         else:
             return False
@@ -190,7 +190,7 @@ class NCFS(object):
         # number of dimensions should remain the same; if it is
         # different, print warning message and abort renaming.
         if len(old_names) != len(new_names):
-            log.warn("number of dimensions of a variable cannot change")
+            log.warning("number of dimensions of a variable cannot change")
             raise ValueError(
                     'old and new dimension list must have the same lenght')
         # Simulate renaming to check if it results in duplicates.
@@ -577,6 +577,8 @@ class NCFS(object):
         return 0
 
     def unlink(self, path):
+        if not self.exists(path):
+            return 0
         if self.is_var_attr(path):
             self.del_var_attr(path)
         elif self.is_var_dir(path):

--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -552,7 +552,7 @@ class NCFS(object):
             raise InternalError('write(): unexpected path %s' % path)
 
     @classmethod
-    def truncate(cls, path, length, fh=None):
+    def truncate(cls, path, length):
         """ Truncate a file that is being writtem to, i.e. when
         removing lines etc. Note that truncate is also called when
         the size of the file is being extended as well as shrunk"""
@@ -677,11 +677,9 @@ class NCFSOperations(Operations):
         log.debug("CREATING directory: {}".format(path))
         return self.ncfs.mkdir(path, mode)
 
-    @classmethod
-    def truncate(cls, path, length, fh):
+    def truncate(self, path, length):
         """Used when shortening files etc. (I.e. removing lines) """
-        return cls.ncfs.truncate(path, length, fh)
-        # return 0
+        return self.ncfs.truncate(path, length)
 
     def unlink(self, path):
         return self.ncfs.unlink(path)

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -125,6 +125,8 @@ def create_test_dataset_1():
     ds.createVariable('foovar', float, dimensions=('x', 'y'))
     v = ds.variables['foovar']
     v.setncattr('fooattr', 'abc')
+    # create global attribute
+    ds.setncattr('attr1', 'attrval1')
     return ds
 
 
@@ -151,9 +153,23 @@ class TestWrite(unittest.TestCase):
 
     def test_deleting_existing_attr(self):
         self.ncfs.unlink('/foovar/fooattr')
-        self.assertRaises(AttributeError,
-                          self.ds.variables['foovar'].getncattr,
-                          'foovar')
+        self.assertTrue('fooattr' not in self.ds.variables['foovar'].ncattrs())
+
+    def test_creating_new_global_attr(self):
+        self.ncfs.create('/attr2', mode=int('0100644', 8))
+        self.assertEqual(self.ds.getncattr('attr2'), '')
+
+    def test_writing_to_existing_global_attr(self):
+        self.ncfs.write('/attr1', 'newattr1val', offset=0)
+        self.assertEqual(self.ds.getncattr('attr1'), 'newattr1val')
+
+    def test_writing_to_existing_global_attr_2(self):
+        self.ncfs.write('/attr1', 'x', offset=0)
+        self.assertEqual(self.ds.getncattr('attr1'), 'xttrval1')
+
+    def test_deleting_existing_global_attr(self):
+        self.ncfs.unlink('/attr1')
+        self.assertTrue('attr1' not in self.ds.ncattrs())
 
 
 class TestDimNamesAsTextFiles(unittest.TestCase):

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -156,7 +156,6 @@ class TestWrite(unittest.TestCase):
         self.assertTrue('fooattr' not in self.ds.variables['foovar'].ncattrs())
 
 
-
 class TestGlobalAttrs(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -155,9 +155,20 @@ class TestWrite(unittest.TestCase):
         self.ncfs.unlink('/foovar/fooattr')
         self.assertTrue('fooattr' not in self.ds.variables['foovar'].ncattrs())
 
+
+
+class TestGlobalAttrs(unittest.TestCase):
+
+    def setUp(self):
+        self.ds = create_test_dataset_1()
+        self.ncfs = NCFS(self.ds, None, None, None)
+
+    def tearDown(self):
+        self.ds.close()
+
     def test_creating_new_global_attr(self):
         self.ncfs.create('/attr2', mode=int('0100644', 8))
-        self.assertEqual(self.ds.getncattr('attr2'), '')
+        self.assertTrue('attr2' in self.ds.ncattrs())
 
     def test_writing_to_existing_global_attr(self):
         self.ncfs.write('/attr1', 'newattr1val', offset=0)
@@ -167,9 +178,24 @@ class TestWrite(unittest.TestCase):
         self.ncfs.write('/attr1', 'x', offset=0)
         self.assertEqual(self.ds.getncattr('attr1'), 'xttrval1')
 
+    def test_is_global_attr_on_existing_attr(self):
+        self.assertTrue(self.ncfs.is_global_attr('/attr1'))
+
+    def test_is_global_attr_on_nonexisting_attr(self):
+        self.assertTrue(self.ncfs.is_global_attr('/attr99'))
+
+    def test_get_global_attr(self):
+        self.assertTrue(self.ncfs.get_global_attr('/attr1') is not None)
+
+    def test_exist_on_global_attr(self):
+        self.assertTrue(self.ncfs.exists('/attr1'))
+
+    def test_is_var_dir_on_existing_global_attr(self):
+        self.assertFalse(self.ncfs.is_var_dir('/attr1'))
+
     def test_deleting_existing_global_attr(self):
         self.ncfs.unlink('/attr1')
-        self.assertTrue('attr1' not in self.ds.ncattrs())
+        self.assertFalse('attr1' in self.ds.ncattrs())
 
 
 class TestDimNamesAsTextFiles(unittest.TestCase):


### PR DESCRIPTION
hi @dvalters,
* truncate() call was broken
* added some unit tests for editing, deleting, creating global attributes