### PR TITLE
implemented truncate() for global and variable attributes

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -604,12 +604,15 @@ class NCFS(object):
         else:
             raise InternalError('write(): unexpected path %s' % path)
 
-    @classmethod
-    def truncate(cls, path, length):
+    def truncate(self, path, length):
         """ Truncate a file that is being writtem to, i.e. when
         removing lines etc. Note that truncate is also called when
         the size of the file is being extended as well as shrunk"""
         return 0
+        if self.is_global_attr(path):
+            old_val = self.get_global_attr(path)
+            new_val = old_val[0:length]
+            self.dataset.setncattr('')
 
     def rename(self, old, new):
         """

--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -50,7 +50,7 @@ def memoize(function):
 def write_to_string(string, buf, offset):
     """
     Implements someting like string[offset:offset+len(buf)] = buf
-    (which is not be possible as strings are immutable).
+    (which is not possible as strings are immutable).
     """
     string = list(string)
     buf = list(buf)
@@ -608,11 +608,19 @@ class NCFS(object):
         """ Truncate a file that is being writtem to, i.e. when
         removing lines etc. Note that truncate is also called when
         the size of the file is being extended as well as shrunk"""
-        return 0
         if self.is_global_attr(path):
+            attr_name = self.get_global_attr_name(path)
             old_val = self.get_global_attr(path)
-            new_val = old_val[0:length]
-            self.dataset.setncattr('')
+            new_val = old_val.ljust(length)[0:length]
+            self.dataset.setncattr(attr_name, new_val)
+        if self.is_var_attr(path):
+            var = self.get_variable(path)
+            attr_name = self.get_attrname(path)
+            old_val = self.get_var_attr(path)
+            new_val = old_val.ljust(length)[0:length]
+            var.setncattr(attr_name, new_val)
+        else:
+            return 0
 
     def rename(self, old, new):
         """

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -155,6 +155,9 @@ class TestWrite(unittest.TestCase):
         self.ncfs.unlink('/foovar/fooattr')
         self.assertTrue('fooattr' not in self.ds.variables['foovar'].ncattrs())
 
+    def test_truncating_attr(self):
+        self.ncfs.truncate('/attr1', 3)
+        self.assertEqual(self.ds.getncattr('attr1'), 'att')
 
 class TestGlobalAttrs(unittest.TestCase):
 

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -155,9 +155,23 @@ class TestWrite(unittest.TestCase):
         self.ncfs.unlink('/foovar/fooattr')
         self.assertTrue('fooattr' not in self.ds.variables['foovar'].ncattrs())
 
-    def test_truncating_attr(self):
+    def test_truncating_global_attr(self):
         self.ncfs.truncate('/attr1', 3)
         self.assertEqual(self.ds.getncattr('attr1'), 'att')
+
+    def test_increasing_global_attr_length(self):
+        self.ncfs.truncate('/attr1', 10)
+        self.assertEqual(self.ds.getncattr('attr1'), 'attrval1  ')
+
+    def test_truncating_variable_attr(self):
+        self.ncfs.truncate('/foovar/fooattr', 2)
+        self.assertEqual(self.ncfs.get_var_attr('/foovar/fooattr'), 'ab')
+
+    def test_increasing_variable_attr_length(self):
+        self.ncfs.truncate('/foovar/fooattr', 10)
+        self.assertEqual(
+                self.ncfs.get_var_attr('/foovar/fooattr'), 'abc       ')
+
 
 class TestGlobalAttrs(unittest.TestCase):
 


### PR DESCRIPTION
@dvalters, I did not implement truncating for Variable's DATA_REPR as not sure if needed - I think we do not want to change length of DATA_REPR when editing