### PR TITLE
refactored writing to (dimension) variables

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -19,7 +19,7 @@ import inspect
 import argparse
 import logging as log
 from fuse import FUSE, FuseOSError, Operations
-from errno import EACCES, ENOENT
+import errno
 
 
 class InternalError(Exception):
@@ -118,6 +118,7 @@ class VardataAsFlatTextFiles(object):
         # ignoring invalid edits?
         if new_data.size != variable[:].size:
             log.warning('write() ignored - would change data array size')
+            raise FuseOSError(errno.EACCES)
         else:
             variable[:] = new_data
 
@@ -475,7 +476,7 @@ class NCFS(object):
             return statdict
         elif not self.exists(path):
             log.debug('getattr: %s does not exist' % path)
-            raise FuseOSError(ENOENT)
+            raise FuseOSError(errno.ENOENT)
         elif self.is_var_dir(path):
             statdict = self.makeIntoDir(statdict)
             statdict["st_size"] = 4096
@@ -530,11 +531,11 @@ class NCFS(object):
             if mode == os.X_OK:
                 mode = os.R_OK
         if not os.access(path, mode):
-            raise FuseOSError(EACCES)
+            raise FuseOSError(errno.EACCES)
 
     def open(self, path, flags):
         if not self.is_file(path):
-            return ENOENT
+            return errno.ENOENT
         return 0
 
     def read(self, path, size, offset):

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -337,6 +337,8 @@ class TestDimensions(unittest.TestCase):
 
 class TestEditingVariables(unittest.TestCase):
 
+    __name__ = ''
+
     def setUp(self):
         self.ds = create_test_dataset_1()
         vardata_repr = VardataAsFlatTextFiles()
@@ -361,7 +363,7 @@ class TestEditingVariables(unittest.TestCase):
         self.assertEqual(list(self.testvar[:]), expected)
 
     @unittest.skip
-    def test_multiple_writes_followed_by_a_release(self):
+    def test_2writes_followed_by_a_release(self):
         self.ncfs.write('/y/DATA_REPR', '7.0\n8.0', 0)
         self.ncfs.write('/y/DATA_REPR', '\n9.0\n', 8)
         self.ncfs.release('/y/DATA_REPR')

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -5,6 +5,8 @@ from fusenetcdf.fusenetcdf import DimNamesAsTextFiles
 from fusenetcdf.fusenetcdf import VardataAsFlatTextFiles
 from fusenetcdf.fusenetcdf import AttributesAsTextFiles
 from fusenetcdf.fusenetcdf import write_to_string
+from fuse import FuseOSError
+import errno
 
 
 class FakeVariable(object):
@@ -356,11 +358,9 @@ class TestEditingVariables(unittest.TestCase):
         self.assertEqual(list(self.testvar[:]), expected)
 
     def test_editing_partial_text_of_dimension_variable(self):
-        self.ncfs.write('/y/DATA_REPR', '7.0\n8.0', 0)
-        # write would result in data array smaller than original
-        # - this edit should be ignored.
-        expected = [4., 5., 6.]
-        self.assertEqual(list(self.testvar[:]), expected)
+        with self.assertRaises(FuseOSError) as cm:
+            self.ncfs.write('/y/DATA_REPR', '7.0\n8.0', 0)
+        self.assertEqual(cm.exception.errno, errno.EACCES)
 
     @unittest.skip
     def test_2writes_followed_by_a_release(self):

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -338,7 +338,7 @@ class TestDimensions(unittest.TestCase):
         vardata_repr = VardataAsFlatTextFiles()
         dimnames_repr = DimNamesAsTextFiles()
         attr_repr = AttributesAsTextFiles()
-        ncfs = NCFS(self.ds, vardata_repr, dimnames_repr, dimnames_repr)
+        ncfs = NCFS(self.ds, vardata_repr, attr_repr, dimnames_repr)
         ncfs.write('/y/DATA_REPR', '7.0\n8.0\n9.0\n', 0)
         self.assertTrue(
                 (ncfs.get_variable('/y/DATA_REPR')[:] == [7., 8., 9.]).all())

--- a/test/test_ncfs.py
+++ b/test/test_ncfs.py
@@ -350,7 +350,7 @@ class TestDimensions(unittest.TestCase):
         vardata_repr = VardataAsFlatTextFiles()
         dimnames_repr = DimNamesAsTextFiles()
         attr_repr = AttributesAsTextFiles()
-        ncfs = NCFS(self.ds, vardata_repr, dimnames_repr, dimnames_repr)
+        ncfs = NCFS(self.ds, vardata_repr, attr_repr, dimnames_repr)
         ncfs.write('/y/DATA_REPR', '7.0\n8.0', 0)
         # write would result in data array smaller than original
         # - this edit should be ignored.


### PR DESCRIPTION
@dvalters writing to variables is more complex than it seemed to me at first!
- In general I think DATA_REPR may be modified by a sequence of multiple write() and truncate() calls followed by a single release() call. Note that a single write() or truncate() call may in principle result in a text that cannot be translated back to data - we should be translating text representation back to data only when we release(), not at each write()/truncate(). I think supporting this may need changes in our architecture.
- Current implementation assumes that editing is done with a single write(2) call. This assumption seems to be working if I edit DATA_REPR with Vim.
- invalid edits are ignored (log.warning()) is printed)