### PR TITLE
Fixes DIMENSIONS file looking like garbage on some systems

### DIFF
--- a/fusenetcdf/fusenetcdf.py
+++ b/fusenetcdf/fusenetcdf.py
@@ -163,7 +163,7 @@ class DimNamesAsTextFiles(object):
 
     def encode(self, dimnames):
         """ Return text representation of a list of dimension names"""
-        s = self._sep.join(dimnames)
+        s = str(self._sep.join(dimnames))
         if not s or s[-1] == '\n':
             return s
         return s + '\n'


### PR DESCRIPTION
Hi @dvalters I have tried the tool on a new system and DIMENSION files looked weird, like it was some 4-byte encoding. I don't know what caused it or why it is a problem on one system and not on the other. Simple fix was to add str() conversion in one place.